### PR TITLE
Update CVE-2022-33891_Apache_Spark_OS_Command_Injection.yml

### DIFF
--- a/CVE-2022-33891_Apache_Spark_OS_Command_Injection.yml
+++ b/CVE-2022-33891_Apache_Spark_OS_Command_Injection.yml
@@ -9,7 +9,7 @@ date: 22/07/2022
 logsource:
    category: webserver
 detection:
-   paramaterEndpoint:
+   parameterEndpoint:
        cs-method: 'GET'
        sc-status: '403'
        c-uri|contains: '?doAs='
@@ -20,7 +20,7 @@ detection:
       - '('
       - ')'
       - '|'
-   condition: paramaterEndpoint AND specialCharacters
+   condition: parameterEndpoint AND specialCharacters
 falsepositives:
    - Unlikely
 level: Critical


### PR DESCRIPTION
Fix typo