### PR TITLE
Adding sigma detections for CVE-2025-33053

### DIFF
--- a/cve-2025-33053-CustomShellHost-exploit.yml
+++ b/cve-2025-33053-CustomShellHost-exploit.yml
@@ -1,0 +1,20 @@
+title: Suspicious Explorer.exe Spawned by CustomShellHost.exe CVE-2025-33053
+id: 9cb5a2f4-f5cd-4b19-8b68-3483d1f4ae35
+description: Detects explorer.exe being spawned by CustomShellHost.exe from unexpected locations.
+author: Immersive Container 7
+date: 2025/06/11
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:
+    ParentImage|endswith: '\CustomShellHost.exe'
+    Image|endswith: '\explorer.exe'
+  filter:
+    Image|in:
+      - 'C:\Windows\explorer.exe'
+      - 'C:\Windows\SysWOW64\explorer.exe'
+  condition: selection and not filter
+level: high
+falsepositives:
+  - Custom deployments of explorer.exe from non-standard paths

--- a/cve-2025-33053-iediagcmd-exploit.yml
+++ b/cve-2025-33053-iediagcmd-exploit.yml
@@ -1,0 +1,20 @@
+title: Suspicious Route.exe Spawned by iediagcmd.exe CVE-2025-33053
+id: b5b4a587-2a14-4d38-9857-c3b739c210af
+description: Detects route.exe being launched from a non-standard location when the parent is iediagcmd.exe
+author: Immersive Container 7
+date: 2025/06/11
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:
+    ParentImage|endswith: '\iediagcmd.exe'
+    Image|endswith: '\route.exe'
+  filter_legit_paths:
+    Image:
+      - 'C:\Windows\System32\route.exe'
+      - 'C:\Windows\SysWOW64\route.exe'
+  condition: selection and not filter_legit_paths
+level: high
+falsepositives:
+  - Custom deployments of route.exe from non-standard paths


### PR DESCRIPTION
Adding two sigma rules for the two identified binaries for the CVE-2025-33053 exploit which has been used in the wild.